### PR TITLE
Add a contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to the Front End Playbook
+
+If you're on this page because you'd like to contribute to the Playbook, that's fantastic! Thank you for getting involved ❤️
+
+Contributing to the Playbook is for everyone. Whether you work at Springer Nature or not, the Playbook is for you - a guide to good working standards and practices that support healthy, happy teams. You don't need to be a developer to get involved. We cover many areas, from cultural and technical writing to specific technical practices. Please adhere to our [language guidelines](/practices/language.md) when you make your contributions. 
+
+## How do I contribute?
+
+### Discussing
+
+You can get involved in discussions in issues and pull requests. Sometimes we need a discussion to [come to an agreement](https://github.com/springernature/frontend/issues/92) on a particular issue before a pull request is opened. Sometimes [a pull request](https://github.com/springernature/frontend/pull/87) will be discussed. Both types of discussion help bring us to a common understanding, and your input at this stage is really valuable. 
+
+### Opening and assigning issues
+
+[Our issues list](https://github.com/springernature/frontend/issues) is half to-do list, half discussion. Not every issue will produce a pull request, and some issues may produce multiple pull requests. 
+
+Create an issue if you notice that there's something missing from the Playbook. If you'd like to discuss the issue with others, use a label like "collaboration", "help wanted", or "question". If you intend to open a pull request to resolve the issue you've created, consider assigning the issue to yourself. 
+
+A good issue is [sufficiently detailed](https://github.com/springernature/frontend/issues/45) for anybody to be able to understand what it's about. If there are existing issues already created that are related to yours, then please link to them to provide further context. 
+
+### Opening pull requests
+
+Please create a new short-lived feature branch for your changes, then create a pull request. Once your changes have been approved, you can merge them to the master branch. [Read more about what we're looking for when we review](practices/code-review.md).
+
+Include a summary of your pull request when you open it. We prefer to use commit messages to explain _what_ a change will do, and pull request summaries to explain _why_ the change was made. [Read further guidelines on commit messages](practices/git.md) - many of these guidelines can also apply to pull request summaries!
+
+If you work at Springer Nature, please remember to keep discussion inside the issues and pull requests, avoiding Slack, hallway conversations etc. Remember that this repo is public, and the discussions we have can be of benefit to people apart from us.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ To contribute please create a new branch for each section, then create a pull re
 
 Please keep discussion inside the issues and pull requests, avoiding Slack, hallway conversations etc. Remember that this repo is public, and the discussions we have can be of benefit to people apart from us.
 
+[Read the full contributor guide](CONTRIBUTING.md).
+
 ## Links
 
 If you need to reuse a hyperlink, turn it into a [reference link](https://daringfireball.net/projects/markdown/syntax#link). Otherwise, use an inline link.


### PR DESCRIPTION
Resolves more of #32 

I think the only thing missing is tone-of-voice guidelines, which should probably go in the language section. 